### PR TITLE
update typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ ansible-container install ansible.nginx-container
     $ cd myproject
 
     # Initialize the project
-    $ ansible-contiainer init
+    $ ansible-container init
     ```
 
 ## Role Variables


### PR DESCRIPTION
ansible-container init  is the correct spelling